### PR TITLE
Add support for Windows build

### DIFF
--- a/include/linux-err.h
+++ b/include/linux-err.h
@@ -2,27 +2,31 @@
 #define __must_check __attribute__((__warn_unused_result__))
 #define __force
 
+#ifndef _WIN32
+#include <stdint.h>
+#endif
+
 #define MAX_ERRNO	4095
 
-#define IS_ERR_VALUE(x) ((unsigned long)(void *)(x) >= (unsigned long)-MAX_ERRNO)
+#define IS_ERR_VALUE(x) ((uintptr_t)(void *)(x) >= (uintptr_t)-MAX_ERRNO)
 
 
-static inline void * __must_check ERR_PTR(long error)
+static inline void * __must_check ERR_PTR(intptr_t error)
 {
 	return (void *) error;
 }
 
-static inline long __must_check PTR_ERR(__force const void *ptr)
+static inline intptr_t __must_check PTR_ERR(__force const void *ptr)
 {
-	return (long) ptr;
+	return (intptr_t) ptr;
 }
 
 static inline bool __must_check IS_ERR(__force const void *ptr)
 {
-	return IS_ERR_VALUE((unsigned long)ptr);
+	return IS_ERR_VALUE((uintptr_t)ptr);
 }
 
 static inline bool __must_check IS_ERR_OR_NULL(__force const void *ptr)
 {
-	return (!ptr) || IS_ERR_VALUE((unsigned long)ptr);
+	return (!ptr) || IS_ERR_VALUE((uintptr_t)ptr);
 }

--- a/include/linux-types.h
+++ b/include/linux-types.h
@@ -1,4 +1,17 @@
 #pragma once
+
+#ifdef _WIN32
+#include <stdint.h>
+typedef int8_t  s8;
+typedef uint8_t  u8;
+typedef int16_t s16;
+typedef uint16_t u16;
+typedef int32_t s32;
+typedef uint32_t u32;
+typedef int64_t s64;
+typedef uint64_t u64;
+typedef s64 loff_t;
+#else
 #include <linux/types.h>
 typedef __s8  s8;
 typedef __u8  u8;
@@ -8,6 +21,7 @@ typedef __s32 s32;
 typedef __u32 u32;
 typedef __s64 s64;
 typedef __u64 u64;
+#endif
 
 #define container_of(ptr, type, member) ({				\
 	void *__mptr = (void *)(ptr);					\
@@ -15,7 +29,7 @@ typedef __u64 u64;
 
 #define BIT(_B) (1 << (_B))
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
-#define BITS_PER_LONG (sizeof(long) * 8)
+#define BITS_PER_LONG (sizeof(intptr_t) * 8)
 #define GENMASK(h, l) \
-	(((~0LU) - (1LU << (l)) + 1) & \
-	 (~0LU >> (BITS_PER_LONG - 1 - (h))))
+	((uintptr_t)(((~0ULL) - (1ULL << (l)) + 1) & \
+	 (~0ULL >> (BITS_PER_LONG - 1 - (h)))))

--- a/include/nand.h
+++ b/include/nand.h
@@ -17,6 +17,10 @@
 #include <errno.h>
 #include <linux-types.h>
 
+#ifdef _WIN32
+#define __always_inline	inline __attribute__((__always_inline__))
+#endif
+
 #define do_div(n,base) ({					\
 	uint32_t __base = (base);				\
 	uint32_t __rem;						\

--- a/include/spi-mem.h
+++ b/include/spi-mem.h
@@ -18,7 +18,11 @@
 #include <linux-types.h>
 #include <linux-err.h>
 
+#ifdef _WIN32
+typedef intptr_t ssize_t;
+#else
 typedef long ssize_t;
+#endif
 struct spi_controller_mem_ops;
 
 #define SPI_MEM_OP_CMD(__opcode, __buswidth)			\

--- a/spi-mem/ch347/ch347.h
+++ b/spi-mem/ch347/ch347.h
@@ -13,7 +13,6 @@
 extern "C" {
 #endif
 
-#include <endian.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <libusb-1.0/libusb.h>

--- a/spi-mem/spi-mem-serprog.c
+++ b/spi-mem/spi-mem-serprog.c
@@ -1,17 +1,169 @@
 #include <spi-mem.h>
 #include <serprog.h>
 #include <linux-types.h>
-#include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <fcntl.h>
 #include <errno.h>
-#include <string.h>
+
+#ifdef _WIN32
+#include <windows.h>
+
+static HANDLE hComPort;
+static DCB dcbOriginal;
+
+static int serial_config(HANDLE hDevice, int speed)
+{
+	DCB dcb;
+
+	memset(&dcb, 0, sizeof(dcb));
+
+	dcb.DCBlength = sizeof(dcb);
+	if (!GetCommState(hDevice, &dcb)) {
+		fprintf(stderr, "serial: failed to get port config, error = %d\n",
+			GetLastError());
+		return -1;
+	}
+
+	dcb.BaudRate = speed;
+	dcb.ByteSize = 8;
+	dcb.fParity = 0;
+	dcb.StopBits = ONESTOPBIT;
+	dcb.fInX = 0;
+	dcb.fOutX = 0;
+
+	if (!SetCommState(hDevice, &dcb)) {
+		fprintf(stderr, "serial: failed to set port config, error = %d\n",
+			GetLastError());
+		return -1;
+	}
+
+	return 0;
+}
+
+static int serial_init(const char *devpath)
+{
+	DWORD dwErrors;
+	char dev[16];
+	uint32_t com;
+	char *end;
+	int ret;
+
+	if (!strncmp(devpath, "\\\\.\\", 4))
+		devpath += 4;
+
+	if (strncasecmp(devpath, "COM", 3)) {
+		fprintf(stderr, "serial: not a serial device path\n");
+		return -EINVAL;
+	}
+
+	com = strtoul(devpath + 3, &end, 10);
+	if (!com || com > 255 || *end) {
+		fprintf(stderr, "serial: not a valid serial device\n");
+		return -EINVAL;
+	}
+
+	/* Make sure to support COM port >= 10 */
+	snprintf(dev, sizeof(dev), "\\\\.\\COM%u", com);
+
+	hComPort = CreateFile(dev, GENERIC_READ | GENERIC_WRITE, 0, NULL,
+			      OPEN_EXISTING, 0, NULL);
+	if (hComPort == INVALID_HANDLE_VALUE) {
+		fprintf(stderr, "serial: failed to open port, error = %u\n",
+			GetLastError());
+		return -ENODEV;
+	}
+
+	memset(&dcbOriginal, 0, sizeof(dcbOriginal));
+
+	dcbOriginal.DCBlength = sizeof(dcbOriginal);
+	if (!GetCommState(hComPort, &dcbOriginal)) {
+		fprintf(stderr, "serial: failed to get port config, error = %u\n",
+			GetLastError());
+		ret = -EIO;
+		goto cleanup;
+	}
+
+	if (!SetupComm(hComPort, 1024, 1024)) {
+		fprintf(stderr, "serial: failed to get port FIFO size, error = %u\n",
+			GetLastError());
+		ret = -EIO;
+		goto cleanup;
+	}
+
+	if (serial_config(hComPort, 4000000) != 0) {
+		ret = -EIO;
+		goto cleanup;
+	}
+
+	if (!ClearCommError(hComPort, &dwErrors, NULL)) {
+		fprintf(stderr, "serial: failed to clear port error, error = %u\n",
+			GetLastError());
+		ret = -EIO;
+		goto cleanup;
+	}
+
+	if (!PurgeComm(hComPort, PURGE_RXABORT | PURGE_RXCLEAR | PURGE_TXABORT |
+				 PURGE_TXCLEAR)) {
+		fprintf(stderr, "serial: failed to flush port, error = %u\n",
+			GetLastError());
+		ret = -EIO;
+		goto cleanup;
+	}
+
+	return 0;
+
+cleanup:
+	CloseHandle(hComPort);
+
+	return ret;
+}
+
+static int serial_cleanup(void)
+{
+	if (!SetCommState(hComPort, &dcbOriginal)) {
+		fprintf(stderr, "serial: failed to restore port config, error = %u\n",
+			GetLastError());
+	}
+
+	CloseHandle(hComPort);
+
+	return 0;
+}
+
+static int serial_read(void *buf, size_t len)
+{
+	DWORD dwBytesRead;
+
+	if (!ReadFile(hComPort, buf, len, &dwBytesRead, NULL)) {
+		fprintf(stderr, "serial: read failed, error = %u\n",
+			GetLastError());
+		return -EIO;
+	}
+
+	return dwBytesRead;
+}
+
+static int serial_write(const void *buf, size_t len)
+{
+	DWORD dwBytesWritten;
+
+	if (!WriteFile(hComPort, buf, len, &dwBytesWritten, NULL)) {
+		fprintf(stderr, "serial: write failed, error = %u\n",
+			GetLastError());
+		return -EIO;
+	}
+
+	FlushFileBuffers(hComPort);
+
+	return dwBytesWritten;
+}
+#else
+#include <unistd.h>
+#include <fcntl.h>
 #include <termios.h>
 
 static int serial_fd;
-u8 zero_buf[4];
 
 static int serial_config(int fd, int speed)
 {
@@ -76,13 +228,29 @@ ERR:
 	return ret;
 }
 
+static int serial_cleanup(void)
+{
+	return close(serial_fd);
+}
+
+static int serial_read(void *buf, size_t len)
+{
+	return read(serial_fd, buf, len);
+}
+
+static int serial_write(const void *buf, size_t len)
+{
+	return write(serial_fd, buf, len);
+}
+#endif
+
 static int serprog_sync()
 {
 	char c;
 	int ret;
 	c = S_CMD_SYNCNOP;
-	write(serial_fd, &c, 1);
-	ret = read(serial_fd, &c, 1);
+	serial_write(&c, 1);
+	ret = serial_read(&c, 1);
 	if (ret != 1) {
 		perror("serprog: sync r1");
 		return -EINVAL;
@@ -91,7 +259,7 @@ static int serprog_sync()
 		fprintf(stderr, "serprog: sync NAK failed.\n");
 		return -EINVAL;
 	}
-	ret = read(serial_fd, &c, 1);
+	ret = serial_read(&c, 1);
 	if (ret != 1) {
 		perror("serprog: sync r2");
 		return -EINVAL;
@@ -106,7 +274,7 @@ static int serprog_sync()
 static int serprog_check_ack()
 {
 	unsigned char c;
-	if (read(serial_fd, &c, 1) <= 0) {
+	if (serial_read(&c, 1) <= 0) {
 		perror("serprog: exec_op: read status");
 		return errno;
 	}
@@ -126,18 +294,18 @@ static int serprog_check_ack()
 static int serprog_exec_op(u8 command, u32 parmlen, u8 *params,
 		    u32 retlen, void *retparms)
 {
-	if (write(serial_fd, &command, 1) < 0) {
+	if (serial_write(&command, 1) < 0) {
 		perror("serprog: exec_op: write cmd");
 		return errno;
 	}
-	if (write(serial_fd, params, parmlen) < 0) {
+	if (serial_write(params, parmlen) < 0) {
 		perror("serprog: exec_op: write param");
 		return errno;
 	}
 	if (serprog_check_ack() < 0)
 		return -EINVAL;
 	if (retlen) {
-		if (read(serial_fd, retparms, retlen) != retlen) {
+		if (serial_read(retparms, retlen) != retlen) {
 			perror("serprog: exec_op: read return buffer");
 			return 1;
 		}
@@ -229,13 +397,13 @@ static int serprog_mem_exec_op(struct spi_mem *mem, const struct spi_mem_op *op)
 	buf[5] = (rdlen >> 8) & 0xff;
 	buf[6] = (rdlen >> 16) & 0xff;
 
-	if (write(serial_fd, buf, 7) != 7) {
+	if (serial_write(buf, 7) != 7) {
 		perror("serprog: spimem_exec_op: write serprog cmd");
 		return errno;
 	}
 
 	buf[0] = op->cmd.opcode;
-	if (write(serial_fd, buf, 1) != 1) {
+	if (serial_write(buf, 1) != 1) {
 		perror("serprog: spimem_exec_op: write opcode");
 		return errno;
 	}
@@ -248,7 +416,7 @@ static int serprog_mem_exec_op(struct spi_mem *mem, const struct spi_mem_op *op)
 			buf[i - 1] = tmp & 0xff;
 			tmp >>= 8;
 		}
-		if (write(serial_fd, buf, op->addr.nbytes) != op->addr.nbytes) {
+		if (serial_write(buf, op->addr.nbytes) != op->addr.nbytes) {
 			perror("serprog: spimem_exec_op: write addr");
 			return errno;
 		}
@@ -257,7 +425,7 @@ static int serprog_mem_exec_op(struct spi_mem *mem, const struct spi_mem_op *op)
 	if (op->dummy.nbytes) {
 		buf[0] = 0;
 		for (i = 0; i < op->dummy.nbytes; i++) {
-			if (write(serial_fd, buf, 1) != 1) {
+			if (serial_write(buf, 1) != 1) {
 				perror("serprog: spimem_exec_op: write dummy");
 				return errno;
 			}
@@ -268,7 +436,7 @@ static int serprog_mem_exec_op(struct spi_mem *mem, const struct spi_mem_op *op)
 		rwpending = op->data.nbytes;
 		rwdone = 0;
 		while (rwpending) {
-			rwsize = write(serial_fd, op->data.buf.out + rwdone, rwpending);
+			rwsize = serial_write(op->data.buf.out + rwdone, rwpending);
 			if (rwsize < 0) {
 				perror("serprog: spimem_exec_op: write data");
 				return errno;
@@ -284,7 +452,7 @@ static int serprog_mem_exec_op(struct spi_mem *mem, const struct spi_mem_op *op)
 		rwpending = op->data.nbytes;
 		rwdone = 0;
 		while (rwpending) {
-			rwsize = read(serial_fd, op->data.buf.in + rwdone, rwpending);
+			rwsize = serial_read(op->data.buf.in + rwdone, rwpending);
 			if (rwsize < 0) {
 				perror("serprog: spimem_exec_op: read data");
 				return errno;
@@ -322,7 +490,7 @@ static int serprog_init(const char *devpath, u32 speed)
 		goto ERR;
 	return 0;
 ERR:
-	close(serial_fd);
+	serial_cleanup();
 	return ret;
 }
 
@@ -333,5 +501,5 @@ struct spi_mem *serprog_probe(const char *devpath)
 
 void serprog_remove(struct spi_mem *mem)
 {
-	close(serial_fd);
+	serial_cleanup();
 }


### PR DESCRIPTION
To support for building for Windows platform, some headers and types are modified to match windows platform.
Currently serprog is disabled on Windows since all the operations on serial device needs to be abstracted for both linux and windows.